### PR TITLE
check for dropTarget not being null in addDropTarget

### DIFF
--- a/src/webcontainer/java/nextapp/echo2/extras/webcontainer/resource/js/DND.js
+++ b/src/webcontainer/java/nextapp/echo2/extras/webcontainer/resource/js/DND.js
@@ -151,8 +151,12 @@ ExtrasDragSource = Core.extend({
     
     addDropTarget: function(dropTargetId) {
         var dropTarget = document.getElementById(dropTargetId);
-        this.dropTargetArray[this.dropTargetArray.length] = dropTarget;
-        this.dropTargetPositions[this.dropTargetPositions.length] = ExtrasDragSource.getElementPosition(dropTarget);
+        // a drop target on a tree may disappear when the tree is collapsed,
+        // if the target is null ignore it.
+        if (dropTarget) {
+    	       this.dropTargetArray[this.dropTargetArray.length] = dropTarget;
+            this.dropTargetPositions[this.dropTargetPositions.length] = ExtrasDragSource.getElementPosition(dropTarget);
+        }
     },
     
     /**


### PR DESCRIPTION
There is a problem with Drag and Drop interaction with echopointng Tree. When a tree node is collapsed and nodes from the branch contain drop targets the targets may not be found in the DOM tree any longer. When the ExtrasDragSource.MessageProcessor processes init messages in processInit() to add the drop targets a null element is referenced. I changed the code to check that dropTarget isn't null. I hit this back in 2009 on a school project before this project was in github. I recently was working on the project porting to maven and saw these files were in maven central, but hit the problem again.